### PR TITLE
Require broom >= 0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
     gt (>= 0.1.0),
     dplyr (>= 0.7.0),
     generics (>= 0.0.2),
-    broom (>= 0.4.1),
+    broom (>= 0.5.1),
     tidyr (>= 0.8.0),
     stringr (>= 1.3.0),
     purrr (>= 0.2.1),


### PR DESCRIPTION
Thanks for the great package! I had broom version `0.5.0` installed and was getting the following error that was resolved by upgrading.

```
Error in UseMethod("tidy") : 
  no applicable method for 'tidy' applied to an object of class "c('glm', 'lm')"
```

From the comments in the thread at https://github.com/tidymodels/broom/issues/528#issuecomment-447534190 it seems that broom version 0.5.1 or greater is required to be able to use `generics::tidy()` internally. I learned a lot from that thread and it may be helpful w.r.t. #23.